### PR TITLE
fix command palette always visually open / not closing / dead arrow keys

### DIFF
--- a/site/styles/home.css
+++ b/site/styles/home.css
@@ -1050,6 +1050,10 @@
   padding-top: 18vh;
 }
 
+.palette-back[hidden] {
+  display: none;
+}
+
 .palette {
   width: min(560px, 92vw);
   background: var(--paper);


### PR DESCRIPTION
.palette-back { display: flex } was an author CSS rule, which always wins over the browser's default user-agent stylesheet rule ([hidden] { display: none }) at equal specificity — so the element rendered as a visible flex box regardless of the `hidden` attribute state that home.site.js's openPalette()/closePalette() were already toggling correctly.

That one CSS bug explained all three reported symptoms: the palette looked permanently open (visual state was decoupled from the real `hidden` state), selecting an item never visually closed it (same decoupling), and arrow keys did nothing before the palette's first real open (the keydown handler branches on `!paletteBack.hidden` to decide open-vs-closed for keyboard purposes, and that property was correctly `true` — closed — the whole time despite the visual bug).

Fix: .palette-back[hidden] { display: none } — higher specificity than the plain .palette-back rule, so it wins regardless of UA-vs-author cascade origin and restores hidden-attribute-driven visibility.

Verified via a genuinely fresh navigation (through about:blank first, since same-document navigations don't rerun the page's inline scripts and masked this during the prior session's testing): computed display is "none" on load, "/" opens it (display: flex), ArrowDown/ArrowUp correctly move the selected item (About -> Experience -> About), and Enter closes it (display: none) after running the selected action.