### PR TITLE
feat(blog): add series hub for multi-part post collections

### DIFF
--- a/apps/blog/.eleventy.js
+++ b/apps/blog/.eleventy.js
@@ -206,6 +206,13 @@ module.exports = function (eleventyConfig) {
       .map(item => item.post);
   });
 
+  // Filter to get posts belonging to a series, ordered by seriesOrder
+  eleventyConfig.addFilter('seriesPosts', function(collection, seriesSlug) {
+    return collection
+      .filter((post) => post.data.series === seriesSlug)
+      .sort((a, b) => (a.data.seriesOrder || 0) - (b.data.seriesOrder || 0));
+  });
+
   // Filter to calculate reading time
   eleventyConfig.addFilter('readingTime', function(content) {
     const wordsPerMinute = 200;

--- a/apps/blog/site/_data/seriesList.js
+++ b/apps/blog/site/_data/seriesList.js
@@ -1,0 +1,10 @@
+module.exports = function () {
+  return [
+    {
+      name: 'Database Systems',
+      slug: 'database-systems',
+      description:
+        'A deep dive into how databases work under the hood — storage engines, indexing, transactions, replication, and the trade-offs behind them.',
+    },
+  ];
+};

--- a/apps/blog/site/_includes/bento.njk
+++ b/apps/blog/site/_includes/bento.njk
@@ -270,9 +270,36 @@
         justify-content: space-between;
       }
 
+      /* ── Series tile ── */
+      .t-series {
+        grid-column: span 4;
+        background: var(--accent-3);
+        color: var(--paper);
+      }
+      .t-series .label { color: rgba(243,237,225,0.6); }
+      .t-series .label::before { background: var(--ink); }
+      .t-series h2 {
+        font-family: var(--display);
+        font-size: clamp(24px, 2.6vw, 32px);
+        line-height: 1.1;
+        margin: 10px 0 auto;
+        font-weight: 400;
+      }
+      .t-series .series-desc {
+        font-size: 12px;
+        line-height: 1.5;
+        color: rgba(243,237,225,0.75);
+        margin-top: 10px;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .t-series:hover { box-shadow: 0 16px 36px rgba(0,0,0,0.12); }
+
       /* ── Topics tile ── */
       .t-topics {
-        grid-column: span 6;
+        grid-column: span 4;
         background: var(--accent-2);
         color: var(--paper);
       }
@@ -302,7 +329,7 @@
 
       /* ── Subscribe (RSS) tile ── */
       .t-subscribe {
-        grid-column: span 6;
+        grid-column: span 4;
         background: var(--tile-2);
       }
       .t-subscribe .rss-head {
@@ -325,11 +352,12 @@
         .t-feature   { grid-column: span 6; grid-row: span 2; }
         .t-second    { grid-column: span 6; grid-row: span 2; }
         .t-post      { grid-column: span 3; }
+        .t-series    { grid-column: span 6; }
         .t-topics    { grid-column: span 6; }
         .t-subscribe { grid-column: span 6; }
       }
       @media (max-width: 640px) {
-        .t-feature, .t-second, .t-topics, .t-subscribe { grid-column: span 2; grid-row: span 2; }
+        .t-feature, .t-second, .t-series, .t-topics, .t-subscribe { grid-column: span 2; grid-row: span 2; }
         .t-post { grid-column: span 2; }
       }
 
@@ -360,6 +388,7 @@
       </div>
       <nav class="nav-links">
         <a href="/posts/">posts</a>
+        <a href="/series/">series</a>
         <a href="/tags/">topics</a>
       </nav>
     </header>

--- a/apps/blog/site/_includes/post.njk
+++ b/apps/blog/site/_includes/post.njk
@@ -209,6 +209,7 @@
       }
       .post-meta-bar .pill:hover { background: var(--ink); color: var(--paper); border-color: var(--ink); }
       .post-meta-bar .pill.cat { background: var(--accent); border-color: var(--accent); color: var(--ink); }
+      .post-meta-bar .pill.series { background: var(--accent-2); border-color: var(--accent-2); color: var(--paper); }
 
       /* ── Prose content ── */
       .post-body { grid-column: 1; }
@@ -465,6 +466,66 @@
       }
       .newsletter-tile a:hover { box-shadow: 0 4px 12px rgba(255,231,66,0.5); }
 
+      /* ── Series nav ── */
+      .series-nav {
+        grid-column: 1 / -1;
+        margin-top: 56px;
+        padding-top: 48px;
+        border-top: 1px solid var(--hair);
+      }
+      .series-nav-label {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin: 0 0 20px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .series-nav-label::before {
+        content: "";
+        width: 6px;
+        height: 6px;
+        background: var(--accent);
+        border-radius: 1px;
+      }
+      .series-nav-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .series-nav-item {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 14px 18px;
+        background: var(--tile);
+        border: 1px solid var(--hair);
+        border-radius: 12px;
+        text-decoration: none;
+        color: var(--ink-soft);
+        transition: background .18s, border-color .18s;
+      }
+      .series-nav-item:hover { background: var(--tile-2); }
+      .series-nav-item--current {
+        background: var(--ink);
+        color: var(--paper);
+        border-color: var(--ink);
+      }
+      .series-nav-index {
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--muted);
+        flex-shrink: 0;
+      }
+      .series-nav-item--current .series-nav-index { color: rgba(243,237,225,0.5); }
+      .series-nav-title {
+        font-size: 14px;
+        font-weight: 500;
+      }
+
       /* ── Related posts ── */
       .related-posts {
         grid-column: 1 / -1;
@@ -570,6 +631,7 @@
       </a>
       <nav class="nav-links">
         <a href="/posts/">posts</a>
+        <a href="/series/">series</a>
         <a href="/tags/">topics</a>
       </nav>
     </header>
@@ -589,6 +651,13 @@
         <div class="post-meta-bar">
           {% if category %}
           <a class="pill cat" href="/category/{{ category | lower | replace(' ', '-') }}/">{{ category }}</a>
+          {% endif %}
+          {% if series %}
+            {% for s in seriesList %}
+              {% if s.slug === series %}
+              <a class="pill series" href="/series/{{ s.slug }}/">series · {{ s.name }}</a>
+              {% endif %}
+            {% endfor %}
           {% endif %}
           <span class="pill">{{ date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) }}</span>
           <span class="pill">{{ content | readingTime }}</span>
@@ -622,6 +691,24 @@
         </div>
         {% endif %}
       </div>
+
+      {% if series %}
+        {% set currentSeriesPosts = collections.posts | seriesPosts(series) %}
+        {% if currentSeriesPosts.length > 1 %}
+        <aside class="series-nav">
+          <div class="series-nav-label">/series</div>
+          <div class="series-nav-list">
+            {% for sp in currentSeriesPosts %}
+            <a class="series-nav-item {% if sp.data.slug === slug %}series-nav-item--current{% endif %}"
+               href="{% if sp.data.url %}{{ sp.data.url }}{% else %}/{{ sp.data.slug }}/{% endif %}">
+              <span class="series-nav-index">{{ '%02d' | format(loop.index) }}</span>
+              <span class="series-nav-title">{{ sp.data.title }}</span>
+            </a>
+            {% endfor %}
+          </div>
+        </aside>
+        {% endif %}
+      {% endif %}
 
       {% set relatedPostsList = collections.posts | relatedPosts(slug, tags, 3) %}
       {% if relatedPostsList.length > 0 %}

--- a/apps/blog/site/posts.md
+++ b/apps/blog/site/posts.md
@@ -54,6 +54,13 @@ description: >
     {% endif %}
   {% endfor %}
 
+  {% set featuredSeries = seriesList[0] %}
+  <a class="tile t-series" href="/series/{{ featuredSeries.slug }}/">
+    <div class="label">/series</div>
+    <h2>{{ featuredSeries.name }}</h2>
+    <p class="series-desc">{{ featuredSeries.description }}</p>
+  </a>
+
   <section class="tile t-topics">
     <div class="label">/topics</div>
     <div class="cloud">

--- a/apps/blog/site/series-detail.njk
+++ b/apps/blog/site/series-detail.njk
@@ -1,0 +1,220 @@
+---
+layout: bento.njk
+pagination:
+  data: seriesList
+  size: 1
+  alias: seriesData
+permalink: "/series/{{ seriesData.slug }}/"
+eleventyComputed:
+  title: "{{ seriesData.name }} — Jenish Jain"
+  seo_title: "{{ seriesData.name }} Series — Jenish Jain's Engineering Blog"
+  description: "{{ seriesData.description }}"
+---
+
+{% set seriesPosts = collections.posts | seriesPosts(seriesData.slug) %}
+
+<main class="series-page">
+
+  <nav class="series-breadcrumb" aria-label="Breadcrumb">
+    <a href="/">home</a>
+    <span>/</span>
+    <a href="/series/">series</a>
+    <span>/</span>
+    <span>{{ seriesData.name }}</span>
+  </nav>
+
+  <div class="series-header">
+    <div class="series-kicker">/series</div>
+    <h1 class="series-title">{{ seriesData.name }}</h1>
+    <p class="series-desc">{{ seriesData.description }}</p>
+    <p class="series-sub">{{ seriesPosts | length }} part{% if seriesPosts | length != 1 %}s{% endif %} published</p>
+  </div>
+
+  {% if seriesPosts | length > 0 %}
+  <ol class="series-posts">
+    {% for post in seriesPosts %}
+      {% if post.data.url %}
+        {% set postHref = post.data.url %}
+        {% set isExternal = true %}
+      {% else %}
+        {% set postHref = "/" + post.data.slug + "/" %}
+        {% set isExternal = false %}
+      {% endif %}
+      <li>
+        <a class="series-post-card" href="{{ postHref }}"{% if isExternal %} target="_blank" rel="noopener noreferrer"{% endif %}>
+          <div class="spc-index">{{ '%02d' | format(loop.index) }}</div>
+          <div class="spc-body">
+            <div class="spc-title">{{ post.data.title }}</div>
+            <p class="spc-desc">{{ post.data.description }}</p>
+            <div class="spc-meta">{{ post.date | simpleDate }}</div>
+          </div>
+          <div class="spc-arrow">→</div>
+        </a>
+      </li>
+    {% endfor %}
+  </ol>
+  {% else %}
+  <div class="series-empty">
+    <p>No parts published yet — this series is in the works.</p>
+  </div>
+  {% endif %}
+
+  <a class="back-link" href="/series/">← all series</a>
+
+</main>
+
+<style>
+  .series-page {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 0 clamp(20px, 4vw, 48px) 80px;
+  }
+  .series-breadcrumb {
+    padding: 20px 0 0;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+  .series-breadcrumb a { color: var(--muted); text-decoration: none; transition: color .15s; }
+  .series-breadcrumb a:hover { color: var(--ink); }
+
+  .series-header {
+    padding: clamp(32px, 5vw, 56px) 0 clamp(28px, 4vw, 40px);
+    border-bottom: 1px solid var(--hair);
+  }
+  .series-kicker {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .series-kicker::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    background: var(--accent);
+    border-radius: 1px;
+  }
+  .series-title {
+    font-family: var(--display);
+    font-size: clamp(40px, 6vw, 72px);
+    font-weight: 400;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    margin: 0 0 16px;
+    color: var(--ink);
+  }
+  .series-desc {
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--muted);
+    max-width: 60ch;
+    margin: 0 0 12px;
+  }
+  .series-sub {
+    font-family: var(--mono);
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 0;
+  }
+
+  .series-posts {
+    list-style: none;
+    margin: 32px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .series-post-card {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    background: var(--tile);
+    border: 1px solid var(--hair);
+    border-radius: var(--radius);
+    padding: 20px 24px;
+    text-decoration: none;
+    color: inherit;
+    transition: transform .3s cubic-bezier(.2,.7,.2,1), box-shadow .3s;
+  }
+  .series-post-card:hover { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(0,0,0,0.08); }
+  .spc-index {
+    font-family: var(--mono);
+    font-size: 22px;
+    color: var(--muted);
+    flex-shrink: 0;
+    width: 40px;
+  }
+  .spc-body { flex: 1; min-width: 0; }
+  .spc-title {
+    font-family: var(--display);
+    font-size: clamp(18px, 2vw, 24px);
+    line-height: 1.15;
+    color: var(--ink);
+  }
+  .spc-desc {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--muted);
+    margin: 8px 0 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .spc-meta {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-top: 12px;
+  }
+  .spc-arrow {
+    font-family: var(--display);
+    font-size: 24px;
+    color: var(--muted);
+    flex-shrink: 0;
+    transition: transform .2s;
+  }
+  .series-post-card:hover .spc-arrow { transform: translateX(3px); color: var(--ink); }
+
+  .series-empty {
+    margin-top: 32px;
+    padding: 40px;
+    background: var(--tile);
+    border: 1px dashed var(--hair);
+    border-radius: var(--radius);
+    text-align: center;
+    color: var(--muted);
+    font-size: 15px;
+  }
+
+  .back-link {
+    display: inline-block;
+    margin-top: 32px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    text-decoration: none;
+    border-bottom: 1px solid var(--hair);
+    padding-bottom: 2px;
+    transition: color .18s, border-color .18s;
+  }
+  .back-link:hover { color: var(--ink); border-color: var(--ink); }
+</style>

--- a/apps/blog/site/series.njk
+++ b/apps/blog/site/series.njk
@@ -1,0 +1,140 @@
+---
+layout: bento.njk
+title: Series
+seo_title: Blog Series | Jenish Jain's Engineering Blog
+description: Multi-part deep dives on a single topic — read them in order.
+permalink: /series/
+---
+
+<main class="series-index-page">
+
+  <div class="series-index-header">
+    <div class="series-index-kicker">/series</div>
+    <h1 class="series-index-title">Multi-part deep dives</h1>
+    <p class="series-index-sub">{{ description }}</p>
+  </div>
+
+  <div class="series-index-grid">
+    {% for series in seriesList %}
+      {% set seriesPosts = collections.posts | seriesPosts(series.slug) %}
+      <a class="series-card" href="/series/{{ series.slug }}/">
+        <div class="series-card-label">/series</div>
+        <h2 class="series-card-name">{{ series.name }}</h2>
+        <p class="series-card-desc">{{ series.description }}</p>
+        <div class="series-card-meta">
+          {% if seriesPosts | length > 0 %}
+            {{ seriesPosts | length }} part{% if seriesPosts | length != 1 %}s{% endif %}
+          {% else %}
+            coming soon
+          {% endif %}
+        </div>
+      </a>
+    {% endfor %}
+  </div>
+
+</main>
+
+<style>
+  .series-index-page {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 clamp(20px, 4vw, 48px) 80px;
+  }
+  .series-index-header {
+    padding: clamp(40px, 6vw, 72px) 0 clamp(32px, 4vw, 48px);
+    border-bottom: 1px solid var(--hair);
+    max-width: 640px;
+  }
+  .series-index-kicker {
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .series-index-kicker::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    background: var(--accent);
+    border-radius: 1px;
+  }
+  .series-index-title {
+    font-family: var(--display);
+    font-size: clamp(36px, 5vw, 64px);
+    font-weight: 400;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    margin: 0 0 16px;
+    color: var(--ink);
+  }
+  .series-index-sub {
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--muted);
+    margin: 0;
+  }
+
+  .series-index-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 12px;
+    margin-top: 32px;
+  }
+  @media (max-width: 640px) { .series-index-grid { grid-template-columns: 1fr; } }
+
+  .series-card {
+    background: var(--ink);
+    color: var(--paper);
+    border-radius: var(--radius);
+    padding: 26px;
+    display: flex;
+    flex-direction: column;
+    text-decoration: none;
+    min-height: 200px;
+    transition: transform .3s cubic-bezier(.2,.7,.2,1), box-shadow .3s;
+  }
+  .series-card:hover { transform: translateY(-3px); box-shadow: 0 16px 36px rgba(0,0,0,0.22); }
+  .series-card-label {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: rgba(243,237,225,0.5);
+    margin-bottom: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .series-card-label::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    background: var(--accent);
+    border-radius: 1px;
+  }
+  .series-card-name {
+    font-family: var(--display);
+    font-size: clamp(24px, 2.6vw, 32px);
+    line-height: 1.1;
+    margin: 0 0 12px;
+  }
+  .series-card-desc {
+    font-size: 14px;
+    line-height: 1.55;
+    color: rgba(243,237,225,0.7);
+    margin: 0 0 auto;
+  }
+  .series-card-meta {
+    margin-top: 20px;
+    font-family: var(--mono);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+</style>


### PR DESCRIPTION
## Summary
Adds structural/UI support for grouping blog posts into series, starting with a "Database Systems" series registration. No placeholder posts are included — pages render a graceful "coming soon" empty state until real posts are added.

- `seriesList.js` — data file registering series (`name`, `slug`, `description`), mirrors existing `categoryList.js`/`tagList.js` pattern
- `/series/` hub page — lists all series as cards with post count or "coming soon"
- `/series/{slug}/` detail page — lists ordered parts of a series (numbered, empty state if none yet)
- `seriesPosts` Eleventy filter — selects and orders posts by `series`/`seriesOrder` front matter
- `post.njk` — shows a series pill + prev/next-style series navigation when a post opts into a series via front matter
- Nav links (`bento.njk`, `post.njk`) and a promo tile on `/posts/` point to the new hub

## How to use going forward
Add `series: database-systems` and `seriesOrder: 1` (etc.) to a post's front matter to have it appear in the series hub/detail pages and post navigation.

## Testing
Verified locally via `npx eleventy` build — inspected generated `dist/series/index.html`, `dist/series/database-systems/index.html`, `dist/posts/index.html`, and `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)