### PR TITLE
Assign Redis capacity planning post to database-systems series

### DIFF
--- a/apps/blog/.eleventy.js
+++ b/apps/blog/.eleventy.js
@@ -90,6 +90,8 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addFilter('limit', (arr, n) => arr.slice(0, n));
 
+  eleventyConfig.addFilter('zeroPad', (num) => String(num).padStart(2, '0'));
+
   eleventyConfig.addFilter('simpleDate', (date) => {
     const d = date instanceof Date ? date : new Date(date);
     return d.toISOString().split('T')[0];

--- a/apps/blog/site/_includes/post.njk
+++ b/apps/blog/site/_includes/post.njk
@@ -701,7 +701,7 @@
             {% for sp in currentSeriesPosts %}
             <a class="series-nav-item {% if sp.data.slug === slug %}series-nav-item--current{% endif %}"
                href="{% if sp.data.url %}{{ sp.data.url }}{% else %}/{{ sp.data.slug }}/{% endif %}">
-              <span class="series-nav-index">{{ '%02d' | format(loop.index) }}</span>
+              <span class="series-nav-index">{{ loop.index | zeroPad }}</span>
               <span class="series-nav-title">{{ sp.data.title }}</span>
             </a>
             {% endfor %}

--- a/apps/blog/site/posts/10-redis-capacity-planning/redis-capacity-planning.md
+++ b/apps/blog/site/posts/10-redis-capacity-planning/redis-capacity-planning.md
@@ -8,6 +8,8 @@ description: >
   A production support question — "our self-managed Redis was at 50% CPU on a 4-core box, but latencies were already climbing, how do we know when to scale?" — turned into a real benchmark investigation, on both a standalone instance and a real primary/replica pair. Here's the metric that actually matters, the thresholds to alert on, and when to scale up vs. scale out.
 category: productivity
 tags: [redis, capacity-planning, performance, devops, sre, monitoring, prometheus, engineering, software-engineering, databases]
+series: database-systems
+seriesOrder: 1
 site: blogsite
 ---
 

--- a/apps/blog/site/series-detail.njk
+++ b/apps/blog/site/series-detail.njk
@@ -42,7 +42,7 @@ eleventyComputed:
       {% endif %}
       <li>
         <a class="series-post-card" href="{{ postHref }}"{% if isExternal %} target="_blank" rel="noopener noreferrer"{% endif %}>
-          <div class="spc-index">{{ '%02d' | format(loop.index) }}</div>
+          <div class="spc-index">{{ loop.index | zeroPad }}</div>
           <div class="spc-body">
             <div class="spc-title">{{ post.data.title }}</div>
             <p class="spc-desc">{{ post.data.description }}</p>


### PR DESCRIPTION
## Summary
- Tags the Redis capacity planning post into the existing "Database Systems" series (`series: database-systems`, `seriesOrder: 1`)
- Fixes a bug in the series hub templates: both `series-detail.njk` and `post.njk`'s series-nav called a nonexistent Nunjucks `format` filter for zero-padding the index number. It never fired before because no post had a `series` value yet — assigning one crashed the build. Added a `zeroPad` filter in `.eleventy.js` and swapped both call sites to use it.

## Test plan
- [x] `npx eleventy` builds cleanly with no template errors
- [x] `/series/database-systems/` renders the post with a `01` index
- [x] Post page shows the `series · Database Systems` pill and series nav sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)