### PR TITLE
Fix This-week stat and add missing time unit

### DIFF
--- a/apps/runs/site/index.html
+++ b/apps/runs/site/index.html
@@ -193,7 +193,8 @@ const svgRoute=(d,stroke,w)=>`<svg viewBox="0 0 100 100" fill="none" aria-hidden
 const timeOf=r=>{const h=r.hour%12||12,m=String(r.minute||0).padStart(2,"0");return `${h}:${m} ${r.hour<12?"am":"pm"}`};
 
 /* ---------- left rail ---------- */
-const week=RUNS.slice(-4);
+const thisIsoWeek=isoWeek(new Date().toISOString().slice(0,10));
+const week=RUNS.filter(r=>isoWeek(r.date)===thisIsoWeek);
 const kvs=rows=>rows.map(([k,v,u])=>`<div class="kv"><span class="k">${k}</span><span class="v">${v}${u?`<small>${u}</small>`:""}</span></div>`).join("");
 $("r-week").innerHTML=kvs([["Distance",week.reduce((s,r)=>s+r.km,0).toFixed(1),"km"],["Time",fmtDur(week.reduce((s,r)=>s+r.moving,0)),""],["Runs",week.length,""]]);
 const sp=weeklyVolume(14),spMax=Math.max(...sp.map(w=>w.km));

--- a/apps/runs/site/index.html
+++ b/apps/runs/site/index.html
@@ -196,7 +196,7 @@ const timeOf=r=>{const h=r.hour%12||12,m=String(r.minute||0).padStart(2,"0");ret
 const thisIsoWeek=isoWeek(new Date().toISOString().slice(0,10));
 const week=RUNS.filter(r=>isoWeek(r.date)===thisIsoWeek);
 const kvs=rows=>rows.map(([k,v,u])=>`<div class="kv"><span class="k">${k}</span><span class="v">${v}${u?`<small>${u}</small>`:""}</span></div>`).join("");
-$("r-week").innerHTML=kvs([["Distance",week.reduce((s,r)=>s+r.km,0).toFixed(1),"km"],["Time",fmtDur(week.reduce((s,r)=>s+r.moving,0)),""],["Runs",week.length,""]]);
+$("r-week").innerHTML=kvs([["Distance",week.reduce((s,r)=>s+r.km,0).toFixed(1),"km"],["Time",fmtDur(week.reduce((s,r)=>s+r.moving,0)),"min"],["Runs",week.length,""]]);
 const sp=weeklyVolume(14),spMax=Math.max(...sp.map(w=>w.km));
 $("r-spark").innerHTML=sp.map((w,i)=>`<i class="${i===sp.length-1?"on":""}" style="height:${Math.max(4,w.km/spMax*100)}%" title="${w.km} km"></i>`).join("");
 $("r-year").innerHTML=kvs([["Distance",Math.round(STATS.km).toLocaleString(),"km"],["Moving",Math.round(STATS.sec/3600),"h"],["Elevation",STATS.elev.toLocaleString(),"m"],["Runs",STATS.runs,""]]);


### PR DESCRIPTION
## Summary
- `week` was `RUNS.slice(-4)` — literally the last 4 runs ever, regardless of date. With sparse recent activity this could span multiple calendar weeks (was showing 10.5km/5 weeks as "This week"). Now filters by the actual current ISO week using the existing `isoWeek()` helper (already used by the volume sparkline).
- The "This week → Time" stat was the only stat chip missing a unit suffix (bare "20:49"). Added "min" to match every other chip's convention.

## Test plan
- [x] Verified in a headless browser: "This week" now shows the correct single current-week run (3.2km, 1 run) instead of a 5-week-spanning total
- [x] "Time" chip now reads "20:49 min"

🤖 Generated with [Claude Code](https://claude.com/claude-code)