### PR TITLE
Document apps/runs and add it to the / command palette

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev-portfolio dev-blog dev-drawings build-portfolio build-blog build-drawings build clean
+.PHONY: help install dev-portfolio dev-blog dev-drawings dev-runs build-portfolio build-blog build-drawings build-runs build clean
 
 help:
 	@echo "Usage:"
@@ -6,9 +6,11 @@ help:
 	@echo "  make dev-portfolio    Start apps/portfolio dev server"
 	@echo "  make dev-blog         Start apps/blog dev server"
 	@echo "  make dev-drawings     Start apps/drawings dev server"
+	@echo "  make dev-runs         Start apps/runs dev server"
 	@echo "  make build-portfolio  Build apps/portfolio to apps/portfolio/dist/"
 	@echo "  make build-blog       Build apps/blog to apps/blog/dist/"
 	@echo "  make build-drawings   Build apps/drawings to apps/drawings/dist/"
+	@echo "  make build-runs       Build apps/runs to apps/runs/dist/"
 	@echo "  make build            Build all apps"
 	@echo "  make clean            Remove dist/ and .cache/ in every app"
 
@@ -24,6 +26,9 @@ dev-blog:
 dev-drawings:
 	npm run dev --workspace=apps/drawings
 
+dev-runs:
+	npm run dev --workspace=apps/runs
+
 build-portfolio:
 	npm run build --workspace=apps/portfolio
 
@@ -33,7 +38,10 @@ build-blog:
 build-drawings:
 	npm run build --workspace=apps/drawings
 
-build: build-portfolio build-blog build-drawings
+build-runs:
+	npm run build --workspace=apps/runs
+
+build: build-portfolio build-blog build-drawings build-runs
 
 clean:
 	rm -rf apps/*/dist apps/*/.cache

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # jenishjain-sites
 
-Monorepo for Jenish Jain's personal sites. Three independent [Eleventy](https://www.11ty.dev/) apps, each its own Netlify deployment to its own domain — merging the repos didn't merge the deploys, so each site keeps building and deploying on its own.
+Monorepo for Jenish Jain's personal sites. Four independent [Eleventy](https://www.11ty.dev/) apps, each its own Netlify deployment to its own domain — merging the repos didn't merge the deploys, so each site keeps building and deploying on its own.
 
 | App | Domain | Status |
 | --- | --- | --- |
 | [`apps/portfolio`](apps/portfolio) | [jenishjain.in](https://jenishjain.in) | [![Netlify Status](https://api.netlify.com/api/v1/badges/b1750240-5592-420d-91be-5c9caea0e885/deploy-status)](https://app.netlify.com/sites/jenishjain/deploys) |
 | [`apps/blog`](apps/blog) | [blog.jenishjain.in](https://blog.jenishjain.in) | [![Netlify Status](https://api.netlify.com/api/v1/badges/e5f62391-a2de-4aa3-a239-70cd1dad8858/deploy-status)](https://app.netlify.com/sites/jenishjain-blog/deploys) |
 | [`apps/drawings`](apps/drawings) | [drawings.jenishjain.in](https://drawings.jenishjain.in) | [![Netlify Status](https://api.netlify.com/api/v1/badges/6142976e-1d89-4558-b7cd-7940e175a260/deploy-status)](https://app.netlify.com/sites/jenishjain-drawings/deploys) |
+| [`apps/runs`](apps/runs) | [runs.jenishjain.in](https://runs.jenishjain.in) | [![Netlify Status](https://api.netlify.com/api/v1/badges/d5686fc7-517f-4957-b964-fb63b27d102b/deploy-status)](https://app.netlify.com/sites/jenishjain-runs/deploys) |
+
+`apps/runs` is a bit different from the other three: its data
+(`site/static/runs-data.js`) isn't hand-authored, it's synced from the
+Strava API by [`.github/workflows/sync-runs.yml`](.github/workflows/sync-runs.yml)
+on a weekly schedule (or `workflow_dispatch` on demand), which commits the
+regenerated file straight to `master` — Netlify's git-based deploy then
+picks it up like any other push. See [`apps/runs/README.md`](apps/runs/README.md)
+for the Strava credential setup and how to run the sync locally.
 
 ## Structure
 
@@ -20,6 +29,7 @@ npm install                          # once, from the repo root
 npm run dev --workspace=apps/portfolio
 npm run dev --workspace=apps/blog
 npm run dev --workspace=apps/drawings
+npm run dev --workspace=apps/runs
 
 npm run build --workspace=apps/<app> # outputs to apps/<app>/dist/
 ```
@@ -28,8 +38,8 @@ Or via the root `Makefile`:
 
 ```sh
 make install         # npm install, once from repo root
-make dev-portfolio    # or dev-blog / dev-drawings
-make build-portfolio   # or build-blog / build-drawings / build (all three)
+make dev-portfolio    # or dev-blog / dev-drawings / dev-runs
+make build-portfolio   # or build-blog / build-drawings / build-runs / build (all four)
 make clean             # remove dist/ and .cache/ in every app
 ```
 

--- a/apps/portfolio/site/scripts/home.site.js
+++ b/apps/portfolio/site/scripts/home.site.js
@@ -162,6 +162,7 @@
       { id: 'gh', label: 'Open GitHub', kind: 'Link', action: function () { window.open('https://github.com/jenish-jain', '_blank'); } },
       { id: 'blog', label: 'Open blog', kind: 'Link', action: function () { window.open('https://blog.jenishjain.in', '_blank'); } },
       { id: 'art', label: 'Open drawings', kind: 'Link', action: function () { window.open('https://drawings.jenishjain.in', '_blank'); } },
+      { id: 'runs', label: 'See my runs', kind: 'Link', action: function () { window.open('https://runs.jenishjain.in', '_blank'); } },
       { id: 'mail', label: 'Email Jenish', kind: 'Link', action: function () { window.location.href = 'mailto:jenishjain6@gmail.com'; } },
       { id: 'theme', label: 'Toggle theme (paper ↔ ink)', kind: 'Action', action: function () {
         var r = document.documentElement;

--- a/apps/portfolio/site/scripts/home.site.js
+++ b/apps/portfolio/site/scripts/home.site.js
@@ -190,6 +190,8 @@
         li.addEventListener('click', function () { it.action(); closePalette(); });
         paletteList.appendChild(li);
       });
+      var selEl = paletteList.children[sel];
+      if (selEl) selEl.scrollIntoView({ block: 'nearest' });
     }
 
     function openPalette() {

--- a/apps/portfolio/site/styles/home.css
+++ b/apps/portfolio/site/styles/home.css
@@ -1056,6 +1056,9 @@
 
 .palette {
   width: min(560px, 92vw);
+  max-height: 78vh;
+  display: flex;
+  flex-direction: column;
   background: var(--paper);
   border: 1px solid var(--hair);
   border-radius: 14px;
@@ -1073,14 +1076,16 @@
   font-family: var(--mono);
   font-size: 14px;
   border-bottom: 1px solid var(--hair);
+  flex: 0 0 auto;
 }
 
 .palette ul {
   list-style: none;
   margin: 0;
   padding: 6px;
-  max-height: 360px;
   overflow: auto;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .palette li {

--- a/apps/runs/Makefile
+++ b/apps/runs/Makefile
@@ -1,0 +1,24 @@
+.PHONY: help install dev build clean sync
+
+help:
+	@echo "Usage:"
+	@echo "  make install   Install dependencies"
+	@echo "  make dev       Start local dev server with live reload"
+	@echo "  make build     Build the site to dist/"
+	@echo "  make clean     Remove the dist/ output directory"
+	@echo "  make sync      Sync runs-data.js from the Strava API (needs .env)"
+
+install:
+	npm install
+
+dev: install
+	npm run dev
+
+build: install
+	npm run build
+
+clean:
+	rm -rf dist
+
+sync:
+	npm run sync:local


### PR DESCRIPTION
## Summary
- Root README: add the `runs.jenishjain.in` row (with Netlify deploy badge) to the sites table, a short note on its Strava-sync-driven data, and extend the documented `npm run dev/build` and Makefile commands to cover it.
- Added `apps/runs/Makefile` matching the `install`/`dev`/`build`/`clean` pattern the other three apps already have (plus a `make sync` shortcut for the Strava sync).
- jenishjain.in's `/` command palette now has a "See my runs" entry linking to runs.jenishjain.in, next to the existing blog/drawings links.

## Test plan
- [x] `make help` / `make build-runs` from repo root work
- [x] `apps/runs/Makefile`'s `make build` works standalone
- [x] `apps/portfolio` builds cleanly with the palette change
- [x] Verified in a headless browser: pressing `/` opens the palette, "See my runs" appears next to "Open blog"/"Open drawings", and typing "runs" filters correctly to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)