### PR TITLE
Update /now box: databases work and ESP alarm clock

### DIFF
--- a/apps/portfolio/site/_includes/about.njk
+++ b/apps/portfolio/site/_includes/about.njk
@@ -31,7 +31,7 @@
         </div>
         <div class="now-row">
           <div class="k">Shipping</div>
-          <div class="v">Pricing experiments at Rapido<small>Production, ~30M+ rides</small></div>
+          <div class="v">Databases at Rapido<small>Production, ~80L+ rides</small></div>
         </div>
         <div class="now-row">
           <div class="k">Reading</div>
@@ -39,7 +39,7 @@
         </div>
         <div class="now-row">
           <div class="k">Tinkering</div>
-          <div class="v">A bean-counter for monthly expenses<small>Go + a stubbornly bad CLI</small></div>
+          <div class="v">An ESP powered alarm clock<small>a copper tube sculpture</small></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Shipping: "Pricing experiments at Rapido" → "Databases at Rapido", production scale updated to ~80L+ rides.
- Tinkering: bean-counter CLI entry → "An ESP powered alarm clock" / "a copper tube sculpture".

## Test plan
- [x] Built `apps/portfolio` and verified in a headless browser: the /now box in the About section shows both updated rows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)