### PR TITLE
Expand experience rows on hover with real highlights

### DIFF
--- a/apps/portfolio/site/_data/experience.js
+++ b/apps/portfolio/site/_data/experience.js
@@ -1,7 +1,55 @@
 module.exports = [
-  { year: '2024 — now',  title: 'Senior Software Engineer',              sub: 'Pricing & marketplace systems, also moved to devops',          at: 'Rapido' },
-  { year: '2022 — 2024', title: 'Software Engineer II',                  sub: 'Owning surge & marketplace pricing',      at: 'Rapido' },
-  { year: '2020 — 2022', title: 'Software Engineer',                     sub: 'From APE to SE — pricing platform',       at: 'Rapido' },
-  { year: '2019 — 2020', title: 'Associate Product Engineer · Intern',   sub: 'First job. First production push.',       at: 'Rapido' },
-  { year: '2018 — 2019', title: 'Freelance IoT Developer',               sub: 'Hardware, firmware, hacking on weekends', at: 'Self'   },
+  {
+    year: '2024 — now',
+    title: 'Senior Software Engineer',
+    sub: 'Pricing & marketplace systems, also moved to devops',
+    at: 'Rapido',
+    details: [
+      'Built a Go/JS credential-management service on HashiCorp Vault for short-lived, scoped DB credentials',
+      'Owns reliability for 20+ MongoDB clusters — zero-downtime v4→v8 upgrades via Terraform/Ansible',
+      'Shipped an infra cost-monitoring dashboard on BigQuery, plus Elasticsearch auth hardening',
+    ],
+  },
+  {
+    year: '2022 — 2024',
+    title: 'Software Engineer II',
+    sub: 'Owning surge & marketplace pricing',
+    at: 'Rapido',
+    details: [
+      'Led architecture decisions, mentored 4-5 engineers',
+      'Redesigned ratecard storage for a 10x request-capacity increase, enabling geo-temporal pricing',
+      'Cut new-city launch time from months to weeks; dynamic TTL cut storage costs 55-60% across 2M+ daily rides',
+    ],
+  },
+  {
+    year: '2020 — 2022',
+    title: 'Software Engineer',
+    sub: 'From APE to SE — pricing platform',
+    at: 'Rapido',
+    details: [
+      'Owned the dynamic pricing engine — 2M+ daily rides at 400 RPS, 99.9% uptime',
+      'Worked with data science on ML-based pricing across 5M+ daily transactions',
+      'Cut fare-estimation API latency 30-40%; built WireMock stubbing for QA',
+    ],
+  },
+  {
+    year: '2019 — 2020',
+    title: 'Associate Product Engineer · Intern',
+    sub: 'First job. First production push.',
+    at: 'Rapido',
+    details: [
+      'Built core microservices for fare estimation, campaigns, and direction services at 400 RPS',
+      'Designed RESTful APIs with monitoring and alerting for system performance',
+    ],
+  },
+  {
+    year: '2018 — 2019',
+    title: 'Freelance IoT Developer',
+    sub: 'Hardware, firmware, hacking on weekends',
+    at: 'Self',
+    details: [
+      'Built a working commercial MVP prototype to monitor air conditioner health for commercial and residential spaces',
+      'Aimed at cutting maintenance costs and automating data collection that was previously manual',
+    ],
+  },
 ];

--- a/apps/portfolio/site/_includes/experience.njk
+++ b/apps/portfolio/site/_includes/experience.njk
@@ -15,6 +15,11 @@
           <small>{{ r.sub }}</small>
         </div>
         <div class="at"><span class="badge">@ {{ r.at }}</span></div>
+        {% if r.details %}
+        <ul class="role-details">
+          {% for d in r.details %}<li>{{ d }}</li>{% endfor %}
+        </ul>
+        {% endif %}
       </div>
       {% endfor %}
     </div>

--- a/apps/portfolio/site/styles/home.css
+++ b/apps/portfolio/site/styles/home.css
@@ -681,7 +681,47 @@
   color: var(--ink);
 }
 
-@media (max-width: 720px) { .role-row { grid-template-columns: 1fr; gap: 6px; } }
+.role-details {
+  grid-column: 1 / -1;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 144px;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height .35s ease, opacity .25s ease, margin-top .35s ease;
+}
+
+.role-row:hover .role-details,
+.role-row:focus-within .role-details {
+  max-height: 240px;
+  opacity: 1;
+  margin-top: 14px;
+}
+
+.role-details li {
+  position: relative;
+  padding-left: 16px;
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.role-details li + li { margin-top: 6px; }
+
+.role-details li::before {
+  content: "—";
+  position: absolute;
+  left: 0;
+  color: var(--accent-ink);
+  opacity: 0.5;
+}
+
+@media (max-width: 720px) {
+  .role-row { grid-template-columns: 1fr; gap: 6px; }
+  .role-details { padding-left: 0; }
+}
 
 /* === Projects === */
 .project-grid {


### PR DESCRIPTION
## Summary
- Each row in the Experience timeline now expands on hover/focus to reveal 2-3 detail bullets, instead of staying static.
- Content is pulled/condensed from `resume-source.md`'s existing real highlights (Vault credential service, 20+ MongoDB clusters, ratecard 10x capacity, dynamic pricing engine at 2M+ daily rides, etc.) — nothing invented.
- Freelance IoT Developer row's detail: built a working commercial MVP prototype to monitor air conditioner health for commercial/residential spaces, aimed at cutting maintenance costs and automating previously-manual data collection.
- Implementation: a `<ul class="role-details">` per row (`grid-column: 1/-1`, `max-height`-transitioned, collapsed by default) that expands on `:hover`/`:focus-within` — no JS needed, no layout shift to sibling rows.

## Test plan
- [x] Built `apps/portfolio` on top of latest `master` (PRs #48-#50 merged) and verified in a headless browser: hovering each row expands exactly that row's bullets and only that row; moving away collapses it; verified via computed `max-height` inspection (not just screenshots) that hover state is correctly exclusive per row

🤖 Generated with [Claude Code](https://claude.com/claude-code)